### PR TITLE
Revert "register_appropriate_date"

### DIFF
--- a/internal/interfaceadapter/repository/participants_repository.go
+++ b/internal/interfaceadapter/repository/participants_repository.go
@@ -71,13 +71,12 @@ func (participantsRepository *ParticipantsRepository) SaveParticipant(
 	second int,
 	macaddress net.HardwareAddr,
 ) error {
-	timestamp := fmt.Sprintf("%d-%d-%d %d:%d:%d", year, month, date, hour, minute, second)
 	sql := `
-	INSERT INTO packet_logs
-	(transit_time, mac_address)
-	VALUES (?, ?);
+	INSERT INTO packet_logs 
+	(mac_address)
+	VALUES (?);
 	`
-	_, err := participantsRepository.participantsGetter.Execute(sql, timestamp, macaddress.String())
+	_, err := participantsRepository.participantsGetter.Execute(sql, macaddress.String())
 	if err != nil {
 		fmt.Println(err)
 		return fmt.Errorf("calling participantsRepository.participantsGetter.Execute: %w", err)


### PR DESCRIPTION
Reverts higuruchi/participant-app#33

Request:
```
{
    "year": 2021,
    "month": 12,
    "date": 16,
    "hour": 14,
    "minute": 11,
    "second": 54,
    "macaddresses": [
        "c4:3c:ea:85:f0:08",
        "2c:d0:5a:27:82:3e"
    ]
}
```

Response:
```
{"Status":true}
```

GET:
```
curl http://192.168.12.14:1323/participants/2021/12/16
{"B1":null,"B2":null,"B3":null,"B4":null}
```

これはだめでは