### PR TITLE
fix API interface: from daate to day

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ git clone https://github.com/higuruchi/participant-app.git
 - HTTP request path
 
     ```
-    /participants/:year/:month/:date
+    /participants/:year/:month/:day
     ```
 
 - Return value

--- a/internal/externalinterface/server/server.go
+++ b/internal/externalinterface/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import(
 	"fmt"
-	"net/http"
 	"github.com/labstack/echo/v4"
 	"github.com/higuruchi/participant-app/internal/config"
 	"github.com/higuruchi/participant-app/internal/interfaceadapter/controller"
@@ -37,11 +36,7 @@ func NewServer(
 }
 
 func (server *server) Run() error {
-	server.echoImplement.GET("/", func(c echo.Context) error {
-		return c.String(http.StatusOK, "Hello World!")
-	})
-
-	server.echoImplement.GET("/participants/:year/:month/:date", server.participantsCtrl.GetParticipants)
+	server.echoImplement.GET("/participants/:year/:month/:day", server.participantsCtrl.GetParticipants)
 	server.echoImplement.POST("/participants", server.participantsCtrl.SaveParticipants)
 	server.echoImplement.POST("/user", server.userCtrl.CreateUser)
 	server.echoImplement.PUT("/macaddr/:id", server.userCtrl.UpdateUserMacaddr)

--- a/internal/interfaceadapter/controller/participants_controller.go
+++ b/internal/interfaceadapter/controller/participants_controller.go
@@ -29,7 +29,7 @@ type ParticipantsReturnData struct {
 type SaveParticipantsData struct {
 	Year int `json: "year"`
 	Month int `json: "month"`
-	Date int `json: date`
+	Day int `json: day`
 	Hour int `json: hour`
 	Minute int `json: minute`
 	Second int `json: second`
@@ -105,12 +105,12 @@ func (participantsCtrl *participantsController) GetParticipants(c echo.Context) 
 		return echo.NewHTTPError(http.StatusBadRequest, "month is required or invalid")
 	}
 
-	date, err := strconv.Atoi(c.Param("date"))
-	if err != nil || date < 1 || 31 < date{
-		return echo.NewHTTPError(http.StatusBadRequest, "date is required or invalid")
+	day, err := strconv.Atoi(c.Param("day"))
+	if err != nil || day < 1 || 31 < day {
+		return echo.NewHTTPError(http.StatusBadRequest, "day is required or invalid")
 	}
 
-	participants, err := participantsCtrl.participantsUsecase.GetParticipants(year, month, date)
+	participants, err := participantsCtrl.participantsUsecase.GetParticipants(year, month, day)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error")
 	}
@@ -127,7 +127,7 @@ func (participantsCtrl *participantsController) SaveParticipants(c echo.Context)
 	
 	year := saveParticipantsData.Year
 	month := saveParticipantsData.Month
-	date := saveParticipantsData.Date
+	day := saveParticipantsData.Day
 	hour := saveParticipantsData.Hour
 	minute := saveParticipantsData.Minute
 	second := saveParticipantsData.Second
@@ -139,7 +139,7 @@ func (participantsCtrl *participantsController) SaveParticipants(c echo.Context)
 			return fmt.Errorf("calling net.ParseMAC: %w", err)
 		}
 
-		err = participantsCtrl.participantsUsecase.SaveParticipant(year, month, date, hour, minute, second, hw)
+		err = participantsCtrl.participantsUsecase.SaveParticipant(year, month, day, hour, minute, second, hw)
 		if err != nil {
 			return fmt.Errorf("calling participantsCtrl.participantsUsecase.SaveParticipant: %w", err)
 		}

--- a/internal/interfaceadapter/repository/participants_repository.go
+++ b/internal/interfaceadapter/repository/participants_repository.go
@@ -20,7 +20,7 @@ func NewParticipantsRepository(
 func (participantsRepository *ParticipantsRepository) GetParticipants(
 	year int,
 	month int,
-	date int,
+	day int,
 ) ([]model.Participant, int, error) {
 	var participants []model.Participant
 
@@ -40,8 +40,8 @@ func (participantsRepository *ParticipantsRepository) GetParticipants(
 	WHERE packet_logs.transit_time BETWEEN ? AND ?
 	`
 
-	from := fmt.Sprintf("%d-%d-%d 00:00:00", year, month, date)
-	end := fmt.Sprintf("%d-%d-%d 23:59:59", year, month, date)
+	from := fmt.Sprintf("%d-%d-%d 00:00:00", year, month, day)
+	end := fmt.Sprintf("%d-%d-%d 23:59:59", year, month, day)
 
 	rows, err := participantsRepository.participantsGetter.Query(sql, from, end)
 	defer rows.Close()
@@ -65,13 +65,13 @@ func (participantsRepository *ParticipantsRepository) GetParticipants(
 func (participantsRepository *ParticipantsRepository) SaveParticipant(
 	year int,
 	month int,
-	date int,
+	day int,
 	hour int,
 	minute int,
 	second int,
 	macaddress net.HardwareAddr,
 ) error {
-	timestamp := fmt.Sprintf("%d-%d-%d %d:%d:%d", year, month, date, hour, minute, second)
+	timestamp := fmt.Sprintf("%d-%d-%d %d:%d:%d", year, month, day, hour, minute, second)
 	sql := `
 	INSERT INTO packet_logs
 	(transit_time, mac_address)

--- a/internal/usecase/participants_usecase.go
+++ b/internal/usecase/participants_usecase.go
@@ -28,7 +28,7 @@ func NewParticipantsUsecase(
 func (participantsUsecase *participantsUsecase) GetParticipants(
 	year int,
 	month int,
-	date int,
+	day int,
 ) (entity.ParticipantsEntity, error) {
 
 	if year < 0 {
@@ -39,11 +39,11 @@ func (participantsUsecase *participantsUsecase) GetParticipants(
 		return nil, errors.New("syntax error; not enough arguments or value is out of range")
 	}
 
-	if date < 1 || 31 < date {
+	if day < 1 || 31 < day {
 		return nil, errors.New("syntax error; not enough arguments or value is out of range")
 	}
 
-	participants, num, err := participantsUsecase.participantsRepository.GetParticipants(year, month, date)
+	participants, num, err := participantsUsecase.participantsRepository.GetParticipants(year, month, day)
 	if err != nil {
 		return nil, fmt.Errorf("calling participantsUsecase.participantsRepository.GetParticipants: %w", err)
 	}
@@ -74,13 +74,13 @@ func (participantsUsecase *participantsUsecase) GetParticipants(
 func (participantsUsecase *participantsUsecase) SaveParticipant(
 	year int,
 	month int,
-	date int,
+	day int,
 	hour int,
 	minute int,
 	second int,
 	macaddress net.HardwareAddr,
 ) error {	
-	err := participantsUsecase.participantsRepository.SaveParticipant(year, month, date, hour, minute, second, macaddress)
+	err := participantsUsecase.participantsRepository.SaveParticipant(year, month, day, hour, minute, second, macaddress)
 	if err != nil {
 		return fmt.Errorf("calling participantsUsecase.participantsRepository.SaveParticipant %w", err)
 	}


### PR DESCRIPTION
Close: #24 

# 内容

APIのインタフェースを修正

## Save participants API

- from
  ```json
  {
    "year": 2021,
    "month": 11,
    "date": 16,
    "hour": 14,
    "minute": 11,
    "second": 54,
    "macaddresses": [
        "c4:3c:ea:85:f0:08",
        "2c:d0:5a:27:82:3e"
    ]
}
  ```

- to
  ```json
  {
      "year": 2021,
      "month": 11,
      "day": 16,
      "hour": 14,
      "minute": 11,
      "second": 54,
      "macaddresses": [
          "c4:3c:ea:85:f0:08",
          "2c:d0:5a:27:82:3e"
      ]
  }
  ```
