### PR TITLE
eliminate participants api data duplication

### DIFF
--- a/internal/interfaceadapter/repository/participants_repository.go
+++ b/internal/interfaceadapter/repository/participants_repository.go
@@ -49,6 +49,8 @@ func (participantsRepository *ParticipantsRepository) GetParticipants(
 		return nil, -1, fmt.Errorf("calling participantsRepository.participantsGetter.Query: %w", err)
 	}
 
+	participantMap := make(map[string]string)
+
 	for rows.Next() {
 		var participant model.Participant
 
@@ -56,7 +58,11 @@ func (participantsRepository *ParticipantsRepository) GetParticipants(
 		if err != nil {
 			return nil, -1, fmt.Errorf("calling rows.Scan: %w", err)
 		}
-		participants = append(participants, participant)
+
+		if _, ok := participantMap[participant.ID]; !ok {
+			participantMap[participant.ID] = participant.Name
+			participants = append(participants, participant)
+		}
 	}
 
 	return participants, len(participants), nil


### PR DESCRIPTION
Close: #28 
# 内容

`/participants`APIから返却されるjsonデータの重複を削除する処理を追加

## デモ

### Before

```json
{
"B1":[
{
"Id": "19T325",
"Name": "higuruchi"
},
{
"Id": "19T325",
"Name": "higuruchi"
}
],
"B2": null,
"B3": null,
"B4": null
}
```

### Afeter

```json
{
"B1":[
{
"Id": "19T325",
"Name": "higuruchi"
}
],
"B2": null,
"B3": null,
"B4": null
}
```