### PR TITLE
Feature/#40 change request content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,17 @@ $ git clone https://github.com/higuruchi/participant-app.git
 - HTTP request header
 
     ```http
-    Content-Type:application/x-www-form-urlencoded
+    Content-Type:application/json
     ```
 
 - HTTP request body
 
-    ```
-    id=19T999&name=kagawataro&macaddress=aa%3Aaa%3Aaa%3Aaa%3Aaa%3Aaa
+    ```json
+    {
+        "id": "19T999",
+        "name": "test-name",
+        "macaddress": "3c:06:30:43:3f:51"
+    }
     ```
 
 ### Update user macaddr
@@ -150,18 +154,20 @@ $ git clone https://github.com/higuruchi/participant-app.git
 - HTTP request path
 
     ```
-    /macaddr/:id
+    /macaddr
     ```
 
 - HTTP request header
 
     ```http
-    Content-Type:application/x-www-form-urlencoded
+    Content-Type:application/json
     ```
 
 - HTTP request body
 
-    ```
-    # macaddress
-    macaddress=aa%3Aaa%3Aaa%3Aaa%3Aaa%3Aaa
+    ```json
+    {
+        "id": "19T999",
+        "macaddress": "3c:06:30:43:3f:51"
+    }
     ```

--- a/internal/entity/participant_entity.go
+++ b/internal/entity/participant_entity.go
@@ -68,6 +68,11 @@ func (participantEntity *participantEntity) GetName() string {
 func (participantEntity *participantEntity) DistinguishGrade() (grade, error) {
 	t := time.Now()
 	nowYear := t.Year()
+	nowMonth := t.Month()
+	if 1 <= nowMonth && nowMonth <= 3 {
+		nowYear--
+	}
+
 	id := participantEntity.GetID();
 	admissionYear, err := strconv.Atoi(fmt.Sprintf("%d%s", 20, id[0:2]))
 	if err != nil {

--- a/internal/externalinterface/server/server.go
+++ b/internal/externalinterface/server/server.go
@@ -39,7 +39,7 @@ func (server *server) Run() error {
 	server.echoImplement.GET("/participants/:year/:month/:day", server.participantsCtrl.GetParticipants)
 	server.echoImplement.POST("/participants", server.participantsCtrl.SaveParticipants)
 	server.echoImplement.POST("/user", server.userCtrl.CreateUser)
-	server.echoImplement.PUT("/macaddr/:id", server.userCtrl.UpdateUserMacaddr)
+	server.echoImplement.PUT("/macaddr", server.userCtrl.UpdateUserMacaddr)
 
 	err := server.echoImplement.Start(fmt.Sprintf(":%d", server.port))
 	if err != nil {


### PR DESCRIPTION
Close: #40 
Close: #42 

# 内容

- ユーザを登録するAPIとユーザのMACアドレスを修正するAPIの```Content-Type```をjsonに変更した
- 年が変わると学年が変わっていないにも関わらず、学年が上がるバグを修正

## Register user

- Method

    **POST**

- HTTP request path

    ```
    /user
    ```

- HTTP request header

    ```http
    Content-Type:application/json
    ```

- HTTP request body

    ```json
    {
        "id": "19T999",
        "name": "test-name",
        "macaddress": "3c:06:30:43:3f:51"
    }
    ```

### Update user macaddr

- Method

    **PUT**

- HTTP request path

    ```
    /macaddr
    ```

- HTTP request header

    ```http
    Content-Type:application/json
    ```

- HTTP request body

    ```json
    {
        "id": "19T999",
        "macaddress": "3c:06:30:43:3f:51"
    }
    ```

